### PR TITLE
Refine habit management logic and clean UI

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,6 @@ import { HabitProvider } from "./store/habits";
 import IntroScreen from "./screens/introScreens/introScreen";
 import { ProfileProvider, useProfile } from "./store/profile";
 import { useFonts } from "expo-font";
-import * as SQLite from "expo-sqlite";
 import { DatabaseProvider } from "./lib/SQLite/databaseProvider";
 
 function AppContent() {
@@ -36,9 +35,3 @@ export default function App() {
   );
 }
 
-// tasks
-// 1. Update Milestones For Disicipline
-// 2. add notifiactions
-// 9. Add Payment shit
-// 12. Fix Radar Chart Being Fucked up
-// 14. Move Functions into libs and call it to functions from there

--- a/components/habitsComponent/habitsComponent.tsx
+++ b/components/habitsComponent/habitsComponent.tsx
@@ -1,17 +1,64 @@
-import { View, StyleSheet, Text, Pressable } from "react-native";
+import { useCallback, useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+
 import { GLOBAL_STYLES } from "../../lib/globalStyles";
-import { LinearGradient } from "expo-linear-gradient";
-import CategoryComponent from "./categoryComponent/categoryComponent";
-import DifficultyComponent from "./difficultyComponent/difficultyComponent";
 import { useHabits } from "../../store/habits";
 import { useProfile } from "../../store/profile";
 import calculateStatGain from "../../lib/statGainedCalculator";
 import calculateStreak from "../../lib/calcStreak";
+import { HabitCategory, HabitDifficulty } from "../../types/habit";
 import { Profile } from "../../types/profile";
 import { useSQLiteContext } from "expo-sqlite";
+import { persistProfile } from "../../lib/profileStorage";
+import { formatDateKey } from "../../lib/dateUtils";
 
-type CategoryKey = "discipline" | "focus" | "wisdom" | "fitness" | "faith";
+type CategoryKey =
+  | "discipline"
+  | "focus"
+  | "wisdom"
+  | "fitness"
+  | "faith"
+  | "finance";
+
+type HabitComponentProps = {
+  id: string;
+  name: string;
+  completed: boolean;
+  streak: number;
+  difficulty: HabitDifficulty;
+  category: HabitCategory;
+  editMode: string | null;
+  setEditMode: React.Dispatch<React.SetStateAction<string | null>>;
+  setModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  calendar?: boolean;
+};
+
+function CompletionToggle({
+  completed,
+  onPress,
+  disabled,
+}: {
+  completed: boolean;
+  onPress: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      style={styles.toggle}
+      onPress={disabled ? undefined : onPress}
+    >
+      <MaterialIcons
+        name={completed ? "check-circle-outline" : "radio-button-unchecked"}
+        size={34}
+        color={
+          completed ? GLOBAL_STYLES.accentColor : GLOBAL_STYLES.secondaryColor
+        }
+      />
+    </Pressable>
+  );
+}
 
 export default function HabitsComponent({
   id,
@@ -21,265 +68,144 @@ export default function HabitsComponent({
   difficulty,
   category,
   setEditMode,
-  editMode,
   setModalVisible,
   calendar,
-}: {
-  id: string;
-  name: string;
-  completed: boolean;
-  streak: number;
-  difficulty: "Easy" | "Medium" | "Hard";
-  category: "Faith" | "Focus" | "Fitness" | "Wisdom";
-  editMode: string | null;
-  setEditMode: React.Dispatch<React.SetStateAction<string | null>>;
-  setModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
-  calendar?: boolean;
-}) {
+  editMode: _editMode,
+}: HabitComponentProps) {
   const { habits, dispatch } = useHabits();
-  const { profile, setProfile } = useProfile();
+  const { setProfile } = useProfile();
   const db = useSQLiteContext();
 
-  // async function handleComplete(id: string) {
-  //   const habit = habits.find((item) => item.id === id);
-  //   if (!habit) return;
+  const isReadOnly = Boolean(calendar);
 
-  //   const categoryKey = habit.category.toLowerCase() as CategoryKey;
-
-  //   const gain = calculateStatGain(
-  //     profile.stats[categoryKey],
-  //     habit.difficulty
-  //   );
-  //   const todayStr = new Date().toLocaleDateString("en-CA").split("T")[0];
-  //   const isCompleted = habit.completed.includes(todayStr);
-
-  //   let updatedCompleted = [...habit.completed];
-
-  //   if (isCompleted) {
-  //     // uncheck - remove date
-  //     updatedCompleted = updatedCompleted.filter((d) => d !== todayStr);
-  //   } else {
-  //     // check - add date
-  //     updatedCompleted.push(todayStr);
-  //   }
-
-  //   // Recalculate streak based on new list
-  //   const newStreak = calculateStreak(updatedCompleted, habit.repeat);
-
-  //   // Update XP
-  //   setProfile((prev) => {
-  //     const newStatValue = Math.max(
-  //       0,
-  //       prev.stats[categoryKey] + (isCompleted ? -gain : gain)
-  //     );
-
-  //     const updatedStats = {
-  //       ...prev.stats,
-  //       [categoryKey]: newStatValue,
-  //     };
-
-  //     const updatedOverall =
-  //       (updatedStats.discipline +
-  //         updatedStats.faith +
-  //         updatedStats.focus +
-  //         updatedStats.fitness +
-  //         updatedStats.wisdom +
-  //         updatedStats.finance) /
-  //       6;
-
-  //     return {
-  //       ...prev,
-  //       stats: {
-  //         ...updatedStats,
-  //         overall: updatedOverall,
-  //       },
-  //     };
-  //   });
-
-  //   dispatch({
-  //     type: "TOGGLE_HABIT",
-  //     payload: { id, date: todayStr, streak: newStreak },
-  //   });
-  // }
-
-  async function handleComplete(id: string) {
-    const habit = habits.find((item) => item.id === id);
-    if (!habit) return;
-
-    const categoryKey = habit.category.toLowerCase() as CategoryKey;
-    const gain = calculateStatGain(
-      profile.stats[categoryKey],
-      habit.difficulty
-    );
-
-    const todayStr = new Date().toLocaleDateString("en-CA").split("T")[0];
-    const isCompleted = habit.completed.includes(todayStr);
-
-    let updatedCompleted = [...habit.completed];
-    if (isCompleted) {
-      updatedCompleted = updatedCompleted.filter((d) => d !== todayStr);
-    } else {
-      updatedCompleted.push(todayStr);
+  const difficultyColor = useMemo(() => {
+    switch (difficulty) {
+      case "Easy":
+        return GLOBAL_STYLES.green;
+      case "Medium":
+        return GLOBAL_STYLES.orange;
+      case "Hard":
+      default:
+        return GLOBAL_STYLES.red;
     }
+  }, [difficulty]);
 
-    const newStreak = calculateStreak(updatedCompleted, habit.repeat);
+  const handleComplete = useCallback(
+    (habitId: string) => {
+      const habit = habits.find((item) => item.id === habitId);
+      if (!habit) {
+        return;
+      }
 
-    // --- FIX START: compute updatedProfile BEFORE setProfile ---
-    const newStatValue = Math.max(
-      0,
-      profile.stats[categoryKey] + (isCompleted ? -gain : gain)
-    );
+      const todayIso = formatDateKey(new Date());
+      const isCompleted = habit.completed?.includes(todayIso) ?? false;
 
-    const updatedStats = {
-      ...profile.stats,
-      [categoryKey]: newStatValue,
-    };
+      const updatedCompleted = isCompleted
+        ? habit.completed.filter((date) => date !== todayIso)
+        : [...habit.completed, todayIso];
 
-    const updatedOverall =
-      (updatedStats.discipline +
-        updatedStats.faith +
-        updatedStats.focus +
-        updatedStats.fitness +
-        updatedStats.wisdom +
-        updatedStats.finance) /
-      6;
+      const newStreak = calculateStreak(updatedCompleted, habit.repeat);
 
-    const updatedProfile: Profile = {
-      ...profile,
-      stats: {
-        ...updatedStats,
-        overall: updatedOverall,
-      },
-    };
+      setProfile((previousProfile) => {
+        const categoryKey = habit.category.toLowerCase() as CategoryKey;
+        const previousStat = previousProfile.stats[categoryKey] ?? 0;
+        const gain = calculateStatGain(previousStat, habit.difficulty);
 
-    setProfile(updatedProfile);
-    // --- FIX END ---
+        const nextStatValue = Math.max(
+          0,
+          previousStat + (isCompleted ? -gain : gain)
+        );
 
-    // Save profile to SQLite
-    await db.runAsync(
-      `INSERT OR REPLACE INTO profile 
-    (id, name, level, currentXP, totalXP, age, paid, streak, stats, milestones)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
-        1,
-        updatedProfile.name,
-        updatedProfile.level,
-        updatedProfile.currentXP,
-        updatedProfile.totalXP,
-        updatedProfile.age,
-        updatedProfile.paid ? 1 : 0,
-        JSON.stringify(updatedProfile.streak),
-        JSON.stringify(updatedProfile.stats),
-        JSON.stringify(updatedProfile.milestones),
-      ]
-    );
+        const updatedStats = {
+          ...previousProfile.stats,
+          [categoryKey]: nextStatValue,
+        };
 
-    // Update habit in Redux / state
-    dispatch({
-      type: "TOGGLE_HABIT",
-      payload: { id, date: todayStr, streak: newStreak },
-    });
-  }
+        const {
+          discipline = 0,
+          faith = 0,
+          finance = 0,
+          fitness = 0,
+          focus = 0,
+          wisdom = 0,
+        } = updatedStats;
 
-  function handleEditMode(id: string) {
+        const nextProfile: Profile = {
+          ...previousProfile,
+          stats: {
+            ...updatedStats,
+            overall:
+              (discipline + faith + finance + fitness + focus + wisdom) / 6,
+          },
+        };
+
+        void persistProfile(db, nextProfile).catch((error) => {
+          console.error(
+            "Failed to persist profile after habit toggle:",
+            error
+          );
+        });
+
+        return nextProfile;
+      });
+
+      dispatch({
+        type: "TOGGLE_HABIT",
+        payload: { id: habitId, date: todayIso, streak: newStreak },
+      });
+    },
+    [db, dispatch, habits, setProfile]
+  );
+
+  const handleToggle = useCallback(() => {
+    if (isReadOnly) {
+      return;
+    }
+    handleComplete(id);
+  }, [handleComplete, id, isReadOnly]);
+
+  const handleEditMode = useCallback(() => {
     setEditMode(id);
     setModalVisible(true);
-  }
+  }, [id, setEditMode, setModalVisible]);
+
   return (
     <Pressable
-      key={id}
-      style={[styles.container, completed ? styles.completed : undefined]}
-      onPress={() => handleEditMode(id)}
+      style={[styles.container, completed && styles.completed]}
+      onPress={handleEditMode}
     >
       <View style={styles.contentContainer}>
-        <View style={{ flexDirection: "row", gap: 9 }}>
-          <View>
-            {completed ? (
-              <Pressable
-                style={{
-                  flex: 1,
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
-                onPress={() => (calendar ? null : handleComplete(id))}
-              >
-                <MaterialIcons
-                  name="check-circle-outline"
-                  size={34}
-                  color={GLOBAL_STYLES.accentColor}
-                  style={{ zIndex: 100 }}
-                />
-              </Pressable>
-            ) : (
-              <Pressable
-                style={{
-                  flex: 1,
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
-                onPress={() => (calendar ? null : handleComplete(id))}
-              >
-                <MaterialIcons
-                  name="radio-button-unchecked"
-                  size={34}
-                  color={GLOBAL_STYLES.secondaryColor}
-                  style={{ zIndex: 100 }}
-                />
-              </Pressable>
-            )}
-          </View>
+        <View style={styles.titleRow}>
+          <CompletionToggle
+            completed={completed}
+            onPress={handleToggle}
+            disabled={isReadOnly}
+          />
+
           <View style={styles.content}>
             <Text
-              style={[
-                styles.title,
-                completed ? styles.completedTitle : undefined,
-              ]}
+              style={[styles.title, completed && styles.completedTitle]}
+              numberOfLines={2}
             >
               {name}
             </Text>
             <View style={styles.desContainer}>
-              {/* <CategoryComponent category={category} /> */}
-              {/* <DifficultyComponent difficulty={difficulty} /> */}
               <Text style={styles.desText}>{category}</Text>
               <Text style={styles.desText}>&#183;</Text>
-              <Text
-                style={[
-                  styles.desText,
-                  {
-                    color:
-                      difficulty === "Easy"
-                        ? GLOBAL_STYLES.green
-                        : difficulty === "Medium"
-                        ? GLOBAL_STYLES.orange
-                        : GLOBAL_STYLES.red,
-                  },
-                ]}
-              >
+              <Text style={[styles.desText, { color: difficultyColor }]}>
                 {difficulty}
               </Text>
             </View>
-            {/* <View style={styles.xpContainer}>
-            <View style={styles.streakContainer}>
-              <MaterialIcons
-                name="local-fire-department"
-                size={14}
-                color="red"
-              />
-              <Text style={styles.steakText}>{streak} days streak</Text>
-            </View>
-          </View> */}
           </View>
         </View>
 
-        <View style={styles.xpContainer}>
-          <View style={styles.streakContainer}>
-            <MaterialIcons
-              name="local-fire-department"
-              size={20}
-              color={GLOBAL_STYLES.accentColor}
-            />
-            <Text style={styles.steakText}>{streak}</Text>
-          </View>
+        <View style={styles.streakContainer}>
+          <MaterialIcons
+            name="local-fire-department"
+            size={20}
+            color={GLOBAL_STYLES.accentColor}
+          />
+          <Text style={styles.streakText}>{streak}</Text>
         </View>
       </View>
     </Pressable>
@@ -292,12 +218,8 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: GLOBAL_STYLES.progressBarBg,
     elevation: 2,
-    // borderRadius: 7,
     paddingHorizontal: 12,
     paddingVertical: 16,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
   },
   completed: {
     backgroundColor: GLOBAL_STYLES.accentColor10,
@@ -306,33 +228,28 @@ const styles = StyleSheet.create({
   contentContainer: {
     flexDirection: "row",
     alignItems: "center",
-    // gap: 10,
-    width: "100%",
     justifyContent: "space-between",
-    // flexWrap: "wrap"
+  },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 9,
+    flex: 1,
+  },
+  content: {
+    flexDirection: "column",
+    flex: 1,
+    gap: 2,
+  },
+  toggle: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
   },
   desContainer: {
     flexDirection: "row",
     gap: 7,
     alignItems: "center",
-  },
-  xpContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-
-    // gap: 10,
-  },
-  streakContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-  },
-
-  content: {
-    flexDirection: "column",
-    width: "75%",
-    // maxWidth: "76%",
-    gap: 2,
   },
   desText: {
     color: GLOBAL_STYLES.secondaryColor,
@@ -341,13 +258,16 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 18,
-    // fontWeight: 600,
     fontFamily: "Cinzel-Medium",
     color: GLOBAL_STYLES.primaryColor,
     flexWrap: "wrap",
   },
-
-  steakText: {
+  streakContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  streakText: {
     fontSize: 18,
     color: GLOBAL_STYLES.accentColor,
   },

--- a/components/modal/inputs/categoryInput/categoryInput.tsx
+++ b/components/modal/inputs/categoryInput/categoryInput.tsx
@@ -1,15 +1,22 @@
 import { View, Text, StyleSheet, Platform } from "react-native";
 import RNPickerSelect from "react-native-picker-select";
 import { GLOBAL_STYLES } from "../../../../lib/globalStyles";
+import { Habit } from "../../../../types/habit";
 
 export default function CategoryInput({
   handleChangeText,
   form,
 }: {
-  handleChangeText: (field: string, value: any) => void;
-  form: { category: string };
+  handleChangeText: <K extends keyof Habit>(field: K, value: Habit[K]) => void;
+  form: Pick<Habit, "category">;
 }) {
-  const categories = ["Faith", "Fitness", "Focus", "Wisdom", "Finance"];
+  const categories: Habit["category"][] = [
+    "Faith",
+    "Fitness",
+    "Focus",
+    "Wisdom",
+    "Finance",
+  ];
 
   return (
     <View style={styles.inputContainer}>

--- a/components/modal/inputs/nameInput.tsx
+++ b/components/modal/inputs/nameInput.tsx
@@ -1,13 +1,13 @@
 import { View, Text, TextInput, StyleSheet } from "react-native";
 import { GLOBAL_STYLES } from "../../../lib/globalStyles";
+import { Habit } from "../../../types/habit";
 
-export default function NameInput({
-  form,
-  handleChangeText,
-}: {
-  form: { name: string };
-  handleChangeText: (field: string, value: any) => void;
-}) {
+type Props = {
+  form: Pick<Habit, "name">;
+  handleChangeText: <K extends keyof Habit>(field: K, value: Habit[K]) => void;
+};
+
+export default function NameInput({ form, handleChangeText }: Props) {
   return (
     <View style={styles.inputContainer}>
       <Text style={styles.inputTitle}>Habit Name</Text>

--- a/components/modal/inputs/pickerInput/pickerInput.tsx
+++ b/components/modal/inputs/pickerInput/pickerInput.tsx
@@ -1,6 +1,7 @@
 import { View, Text, StyleSheet } from "react-native";
 import Slider from "@react-native-community/slider";
 import { GLOBAL_STYLES } from "../../../../lib/globalStyles";
+import { Habit } from "../../../../types/habit";
 
 export default function PickerInput({
   sliderValue,
@@ -9,9 +10,13 @@ export default function PickerInput({
 }: {
   sliderValue: number;
   setSliderValue: React.Dispatch<React.SetStateAction<number>>;
-  handleChangeText: (field: string, value: any) => void;
+  handleChangeText: <K extends keyof Habit>(field: K, value: Habit[K]) => void;
 }) {
-  const difficultyLabels = ["Easy", "Medium", "Hard"];
+  const difficultyLabels: Habit["difficulty"][] = [
+    "Easy",
+    "Medium",
+    "Hard",
+  ];
 
   return (
     <View>

--- a/components/modal/inputs/repeatInput/reapeatCustom.tsx
+++ b/components/modal/inputs/repeatInput/reapeatCustom.tsx
@@ -7,7 +7,7 @@ export default function RepeatCustom({
   handleChangeText,
 }: {
   form: Habit;
-  handleChangeText: (field: string, value: any) => void;
+  handleChangeText: <K extends keyof Habit>(field: K, value: Habit[K]) => void;
 }) {
   const weekDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 

--- a/components/modal/inputs/repeatInput/repeatInput.tsx
+++ b/components/modal/inputs/repeatInput/repeatInput.tsx
@@ -1,14 +1,38 @@
 import { View, Pressable, Text, StyleSheet } from "react-native";
 import { GLOBAL_STYLES } from "../../../../lib/globalStyles";
+import { Habit, HabitRepeat } from "../../../../types/habit";
 
 export default function RepeatInput({
   form,
   handleChangeText,
 }: {
-  form: { repeat: { type: string; days: string[] } };
-  handleChangeText: (field: string, value: any) => void;
+  form: Pick<Habit, "repeat">;
+  handleChangeText: <K extends keyof Habit>(field: K, value: Habit[K]) => void;
 }) {
-  const FREQUENCY_REPEAT = ["Daily", "Once", "Custom"];
+  const FREQUENCY_REPEAT: HabitRepeat["type"][] = [
+    "Daily",
+    "Once",
+    "Custom",
+  ];
+
+  const handleFrequencyPress = (frequency: HabitRepeat["type"]) => {
+    switch (frequency) {
+      case "Once":
+        handleChangeText("repeat", {
+          type: "Once",
+          days: [],
+          selectedDate:
+            form.repeat.type === "Once" ? form.repeat.selectedDate : undefined,
+        });
+        break;
+      case "Custom":
+        handleChangeText("repeat", { type: "Custom", days: [] });
+        break;
+      default:
+        handleChangeText("repeat", { type: "Daily", days: [] });
+        break;
+    }
+  };
   return (
     <View style={styles.inputContainer}>
       <Text style={styles.inputTitle}>Repeat</Text>
@@ -20,7 +44,7 @@ export default function RepeatInput({
               styles.frequency,
               form.repeat.type === freq ? styles.active : undefined,
             ]}
-            onPress={() => handleChangeText("repeat", { type: freq, days: [] })}
+            onPress={() => handleFrequencyPress(freq)}
           >
             <Text
               style={[

--- a/components/modal/inputs/repeatInput/repeatOnce.tsx
+++ b/components/modal/inputs/repeatInput/repeatOnce.tsx
@@ -16,15 +16,18 @@ export default function RepeatOnce({
   form: Habit;
   selectedDate: string | null;
   setSelectedDate: React.Dispatch<React.SetStateAction<string | null>>;
-  handleChangeText: (field: string, value: any) => void;
+  handleChangeText: <K extends keyof Habit>(field: K, value: Habit[K]) => void;
 }) {
+  const activeSelection =
+    form.repeat.type === "Once" ? form.repeat.selectedDate : undefined;
+
   return (
     <View style={styles.inputContainer}>
       <Text style={styles.inputTitle}>Select Date</Text>
 
       <Pressable style={styles.input} onPress={() => setShowCalendar(true)}>
         <Text style={{ color: GLOBAL_STYLES.primaryColor }}>
-          {form.repeat.selectedDate || "Pick your day"}
+          {activeSelection || "Pick your day"}
         </Text>
       </Pressable>
 

--- a/components/modal/modal.tsx
+++ b/components/modal/modal.tsx
@@ -8,7 +8,7 @@ import {
   ScrollView,
 } from "react-native";
 import { GLOBAL_STYLES } from "../../lib/globalStyles";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useHabits } from "../../store/habits";
 import NameInput from "./inputs/nameInput";
 import CategoryInput from "./inputs/categoryInput/categoryInput";
@@ -19,6 +19,20 @@ import PickerInput from "./inputs/pickerInput/pickerInput";
 import ModalBtn from "./modalBtn/modalBtn";
 import ModalHeader from "./modalHeader/modalHeader";
 import { Habit } from "../../types/habit";
+import { formatDateKey } from "../../lib/dateUtils";
+
+function buildInitialForm(): Habit {
+  return {
+    id: Date.now().toString(),
+    name: "",
+    createDate: formatDateKey(new Date()),
+    completed: [],
+    streak: 0,
+    difficulty: "Medium",
+    repeat: { type: "Daily", days: [] },
+    category: "Faith",
+  };
+}
 export default function ModalHabit({
   setModalVisible,
   visible,
@@ -30,31 +44,42 @@ export default function ModalHabit({
   editMode: string | null;
   setEditMode: React.Dispatch<React.SetStateAction<string | null>>;
 }) {
-  const initialForm: Habit = {
-    id: Date.now().toString(),
-    name: "",
-    createDate: new Date().toLocaleDateString("en-CA").split("T")[0],
-    completed: [],
-    streak: 0,
-    difficulty: "Medium",
-    repeat: { type: "Daily", days: [] },
-    category: "Faith",
-  };
-  const [form, setForm] = useState(initialForm);
+  const [form, setForm] = useState<Habit>(() => buildInitialForm());
   const [showCalendar, setShowCalendar] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const { habits, dispatch } = useHabits();
   const editing = editMode !== null;
   const [sliderValue, setSliderValue] = useState(1);
 
+  const difficultyLabels = useMemo(() => ["Easy", "Medium", "Hard"], []);
+
   useEffect(() => {
-    if (editing) {
-      const currectHabit = habits.find((item) => item.id === editMode);
-      if (currectHabit) {
-        setForm(currectHabit);
-      }
+    if (!editing) {
+      setForm(buildInitialForm());
+      setSliderValue(1);
+      setSelectedDate(null);
+      return;
     }
-  }, [editing, habits, editMode]);
+
+    const currentHabit = habits.find((item) => item.id === editMode);
+    if (!currentHabit) {
+      return;
+    }
+
+    setForm(currentHabit);
+    setSliderValue(
+      Math.max(
+        0,
+        difficultyLabels.indexOf(currentHabit.difficulty ?? "Medium")
+      )
+    );
+
+    if (currentHabit.repeat.type === "Once") {
+      setSelectedDate(currentHabit.repeat.selectedDate ?? null);
+    } else {
+      setSelectedDate(null);
+    }
+  }, [difficultyLabels, editMode, editing, habits]);
 
   function handleAdd() {
     if (!form.name) {
@@ -71,14 +96,17 @@ export default function ModalHabit({
       );
       return;
     }
-    // const difficulty = estimateDifficulty(form);
-    const difficultyLabels = ["Easy", "Medium", "Hard"];
-    const difficulty = (difficultyLabels[sliderValue] ?? "Medium") as
-      | "Easy"
-      | "Medium"
-      | "Hard";
+    const difficulty = (difficultyLabels[sliderValue] ?? "Medium") as Habit["difficulty"];
 
-    dispatch({ type: "ADD_HABIT", payload: { ...form, difficulty } });
+    dispatch({
+      type: "ADD_HABIT",
+      payload: {
+        ...form,
+        id: Date.now().toString(),
+        createDate: formatDateKey(new Date()),
+        difficulty,
+      },
+    });
     handleClick();
   }
 
@@ -127,12 +155,12 @@ export default function ModalHabit({
   function handleClick() {
     setModalVisible((prev) => !prev);
     setEditMode(null);
-    setForm(initialForm);
+    setForm(buildInitialForm());
     setSelectedDate(null);
     setSliderValue(1);
   }
 
-  function handleChangeText(field: string, value: any) {
+  function handleChangeText<K extends keyof Habit>(field: K, value: Habit[K]) {
     setForm((prev) => ({ ...prev, [field]: value }));
   }
   return (

--- a/lib/dateUtils.ts
+++ b/lib/dateUtils.ts
@@ -1,0 +1,25 @@
+export function formatDateKey(date: Date): string {
+  return date.toLocaleDateString("en-CA").split("T")[0];
+}
+
+export function getShortWeekday(value: Date | string): string {
+  const date = typeof value === "string" ? new Date(value) : value;
+  return date.toLocaleDateString("en-US", { weekday: "short" });
+}
+
+export function getHeaderLabel(date: Date): string {
+  const weekday = date
+    .toLocaleDateString("en-US", { weekday: "long" })
+    .toLowerCase();
+  const month = date
+    .toLocaleDateString("en-US", { month: "long" })
+    .toLowerCase();
+
+  return `${weekday}, ${date.getDate()} ${month}`;
+}
+
+export function getYesterday(date: Date): Date {
+  const previousDay = new Date(date);
+  previousDay.setDate(previousDay.getDate() - 1);
+  return previousDay;
+}

--- a/lib/habitSelectors.ts
+++ b/lib/habitSelectors.ts
@@ -1,0 +1,62 @@
+import { Habit } from "../types/habit";
+import { formatDateKey, getShortWeekday } from "./dateUtils";
+
+export function selectHabitsForDate(
+  habits: Habit[],
+  isoDate: string
+): Habit[] {
+  const dayName = getShortWeekday(isoDate);
+
+  return habits.filter((habit) => {
+    if (!habit.repeat) return false;
+
+    const createdOn = habit.createDate || formatDateKey(new Date());
+    if (createdOn > isoDate) return false;
+
+    switch (habit.repeat.type) {
+      case "Daily":
+        return true;
+      case "Once":
+        return habit.repeat.selectedDate === isoDate;
+      case "Custom":
+        return habit.repeat.days?.includes(dayName);
+      default:
+        return false;
+    }
+  });
+}
+
+export function countCompletedHabits(
+  habits: Habit[],
+  isoDate: string
+): number {
+  return habits.reduce((total, habit) => {
+    return habit.completed?.includes(isoDate) ? total + 1 : total;
+  }, 0);
+}
+
+export function mapUniqueCompletionDaysByPillar(
+  habits: Habit[]
+): Record<string, number> {
+  const uniqueDays: Record<string, Set<string>> = {};
+
+  habits.forEach((habit) => {
+    if (!habit.category) return;
+
+    if (!uniqueDays[habit.category]) {
+      uniqueDays[habit.category] = new Set();
+    }
+
+    habit.completed?.forEach((date) => {
+      uniqueDays[habit.category]?.add(date);
+    });
+  });
+
+  return Object.entries(uniqueDays).reduce<Record<string, number>>(
+    (acc, [pillar, dates]) => {
+      acc[pillar] = dates.size;
+      return acc;
+    },
+    {}
+  );
+}

--- a/lib/navData.tsx
+++ b/lib/navData.tsx
@@ -2,9 +2,10 @@ import CalendarScreen from "../screens/mainScreens/calendarScreen";
 import DashboardScreen from "../screens/mainScreens/dashboardScreen";
 import MilestoneScreen from "../screens/mainScreens/milestoneScreen";
 import StatsScreen from "../screens/mainScreens/statsScreen";
-import { TouchableOpacity, View } from "react-native";
+import { TouchableOpacity, View, type ViewStyle } from "react-native";
 import { GLOBAL_STYLES } from "./globalStyles";
 import { AntDesign } from "@expo/vector-icons";
+import type { BottomTabNavigationOptions } from "@react-navigation/bottom-tabs";
 
 export const NAV_DATA = [
   {
@@ -45,7 +46,13 @@ export const NAV_DATA = [
   },
 ];
 
-export const SCREEN_OPTIONS = {
+const tabBarItemStyle: ViewStyle = {
+  flex: 1,
+  justifyContent: "center",
+  alignItems: "center",
+};
+
+export const SCREEN_OPTIONS: BottomTabNavigationOptions = {
   headerTitle: () => null,
   headerBackground: () => (
     <View style={{ flex: 1, backgroundColor: GLOBAL_STYLES.bg }} />
@@ -57,11 +64,7 @@ export const SCREEN_OPTIONS = {
     elevation: 0,
     shadowOpacity: 0,
   },
-  tabBarItemStyle: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  },
+  tabBarItemStyle: tabBarItemStyle,
   tabBarLabel: () => null,
 
   tabBarButton: (props: any) => (
@@ -69,12 +72,7 @@ export const SCREEN_OPTIONS = {
       {...props}
       style={[
         props.style,
-        {
-          flex: 1,
-
-          alignItems: "center",
-          justifyContent: "center",
-        },
+        tabBarItemStyle,
       ]}
     />
   ),

--- a/lib/profileProgress.ts
+++ b/lib/profileProgress.ts
@@ -1,0 +1,146 @@
+import { Habit } from "../types/habit";
+import { Profile } from "../types/profile";
+import { mapUniqueCompletionDaysByPillar } from "./habitSelectors";
+import { formatDateKey, getYesterday } from "./dateUtils";
+
+const DISCIPLINE_DECAY_RATE = 0.05;
+const DISCIPLINE_REWARD = 0.15;
+const MAX_STAT_VALUE = 100;
+
+type DailyProgressInput = {
+  completedCount: number;
+  totalHabits: number;
+  today: Date;
+  todayIso: string;
+};
+
+export function applyDailyProgress(
+  previous: Profile,
+  { completedCount, totalHabits, today, todayIso }: DailyProgressInput
+): Profile {
+  if (totalHabits === 0) {
+    return previous;
+  }
+
+  const streak = previous.streak ?? [];
+  const lastStreakDate = streak[streak.length - 1] ?? null;
+  const yesterdayIso = formatDateKey(getYesterday(today));
+
+  let updatedStreak = streak;
+
+  if (completedCount === totalHabits) {
+    if (lastStreakDate === todayIso) {
+      updatedStreak = streak;
+    } else if (lastStreakDate === yesterdayIso) {
+      updatedStreak = [...streak, todayIso];
+    } else {
+      updatedStreak = [todayIso];
+    }
+  } else {
+    if (lastStreakDate === todayIso) {
+      updatedStreak = streak.slice(0, -1);
+    } else if (
+      lastStreakDate &&
+      lastStreakDate !== yesterdayIso &&
+      lastStreakDate !== todayIso
+    ) {
+      updatedStreak = [];
+    }
+  }
+
+  const lastUpdateStr = previous.lastDisciplineUpdate ?? previous.lastUpdateDate ?? "";
+  const lastUpdateDate = lastUpdateStr ? new Date(lastUpdateStr) : undefined;
+
+  let daysMissed = 0;
+  if (lastUpdateDate) {
+    const diffTime = today.getTime() - lastUpdateDate.getTime();
+    daysMissed = Math.max(Math.floor(diffTime / (1000 * 60 * 60 * 24)) - 1, 0);
+  }
+
+  let newDiscipline = previous.stats.discipline ?? 0;
+  if (daysMissed > 0) {
+    newDiscipline *= Math.pow(1 - DISCIPLINE_DECAY_RATE, daysMissed);
+  }
+
+  const awardedDates = previous.pointsAwardedDates ?? [];
+  const hasAwardedToday = awardedDates.includes(todayIso);
+  let updatedAwardedDates = awardedDates;
+
+  if (completedCount === totalHabits && !hasAwardedToday) {
+    newDiscipline = Math.min(MAX_STAT_VALUE, newDiscipline + DISCIPLINE_REWARD);
+    updatedAwardedDates = [...awardedDates, todayIso];
+  } else if (completedCount !== totalHabits && hasAwardedToday) {
+    newDiscipline = Math.max(0, newDiscipline - DISCIPLINE_REWARD);
+    updatedAwardedDates = awardedDates.filter((date) => date !== todayIso);
+  }
+
+  const updatedStats = {
+    ...previous.stats,
+    discipline: newDiscipline,
+  };
+
+  const {
+    discipline = 0,
+    faith = 0,
+    finance = 0,
+    fitness = 0,
+    focus = 0,
+    wisdom = 0,
+  } = updatedStats;
+
+  const newOverall =
+    (discipline + faith + finance + fitness + focus + wisdom) / 6;
+
+  const statsChanged =
+    updatedStats.discipline !== previous.stats.discipline ||
+    newOverall !== previous.stats.overall;
+
+  const streakChanged = updatedStreak !== streak;
+  const awardsChanged = updatedAwardedDates !== awardedDates;
+  const lastUpdateChanged = previous.lastDisciplineUpdate !== todayIso;
+
+  if (!statsChanged && !streakChanged && !awardsChanged && !lastUpdateChanged) {
+    return previous;
+  }
+
+  return {
+    ...previous,
+    streak: updatedStreak,
+    stats: {
+      ...updatedStats,
+      overall: newOverall,
+    },
+    pointsAwardedDates: updatedAwardedDates,
+    lastDisciplineUpdate: todayIso,
+  };
+}
+
+export function updateMilestonesFromHabits(
+  profile: Profile,
+  habits: Habit[]
+): Profile {
+  if (!profile.milestones.length) {
+    return profile;
+  }
+
+  const uniqueCompletions = mapUniqueCompletionDaysByPillar(habits);
+
+  const updatedMilestones = profile.milestones.map((milestone) => ({
+    ...milestone,
+    completed:
+      (uniqueCompletions[milestone.pillar] ?? 0) >= milestone.daysRequired,
+  }));
+
+  const hasChanged = profile.milestones.some((milestone, index) => {
+    return milestone.completed !== updatedMilestones[index]?.completed;
+  });
+
+  if (!hasChanged) {
+    return profile;
+  }
+
+  return {
+    ...profile,
+    milestones: updatedMilestones,
+  };
+}

--- a/lib/profileStorage.ts
+++ b/lib/profileStorage.ts
@@ -1,0 +1,28 @@
+import { type SQLiteDatabase } from "expo-sqlite";
+import { Profile } from "../types/profile";
+
+export async function persistProfile(
+  db: SQLiteDatabase,
+  profile: Profile
+): Promise<void> {
+  await db.runAsync(
+    `INSERT OR REPLACE INTO profile
+      (id, name, level, currentXP, totalXP, age, paid, streak, stats, milestones, pointsAwardedDates, lastDisciplineUpdate, lastUpdateDate)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      1,
+      profile.name,
+      profile.level,
+      profile.currentXP,
+      profile.totalXP,
+      profile.age,
+      profile.paid ? 1 : 0,
+      JSON.stringify(profile.streak ?? []),
+      JSON.stringify(profile.stats),
+      JSON.stringify(profile.milestones),
+      JSON.stringify(profile.pointsAwardedDates ?? []),
+      profile.lastDisciplineUpdate ?? "",
+      profile.lastUpdateDate ?? "",
+    ]
+  );
+}

--- a/screens/mainScreens/calendarScreen.tsx
+++ b/screens/mainScreens/calendarScreen.tsx
@@ -1,46 +1,32 @@
 import { Text, View, StyleSheet } from "react-native";
-import ScreenContainer from "../../components/screenContainer/screenContainer";
 import { useMemo, useState } from "react";
 import { Calendar } from "react-native-calendars";
+
+import ScreenContainer from "../../components/screenContainer/screenContainer";
 import { GLOBAL_STYLES } from "../../lib/globalStyles";
 import { useHabits } from "../../store/habits";
-import moment from "moment";
 import HabitsComponent from "../../components/habitsComponent/habitsComponent";
 import MainHeader from "../../components/mainHeader/mainHeader";
+import { formatDateKey } from "../../lib/dateUtils";
+import {
+  countCompletedHabits,
+  selectHabitsForDate,
+} from "../../lib/habitSelectors";
 
 export default function CalendarScreen() {
-  const today = new Date();
-  const todayStr = today.toLocaleDateString("en-CA").split("T")[0];
-
+  const todayStr = formatDateKey(new Date());
   const [selectedDate, setSelectedDate] = useState<string>(todayStr);
   const { habits } = useHabits();
 
-  const displayDate = useMemo(() => {
-    if (!selectedDate) return [];
+  const displayDate = useMemo(
+    () => selectHabitsForDate(habits, selectedDate),
+    [habits, selectedDate]
+  );
 
-    const dayName = new Date(selectedDate).toLocaleDateString("en-US", {
-      weekday: "short",
-    });
-
-    return habits.filter((habit) => {
-      const { type, days, selectedDate: habitDate } = habit.repeat;
-
-      const habitCreatedAt = habit.createDate; // depends on what you used
-      if (habitCreatedAt > selectedDate) return false;
-
-      if (type === "Daily") return true;
-
-      if (type === "Once" && habitDate === selectedDate) return true;
-
-      if (type === "Custom" && days.includes(dayName)) return true;
-
-      return false;
-    });
-  }, [habits, selectedDate]);
-
-  const completedArray = displayDate.filter((item) =>
-    item.completed.includes(selectedDate)
-  ).length;
+  const completedArray = useMemo(
+    () => countCompletedHabits(displayDate, selectedDate),
+    [displayDate, selectedDate]
+  );
 
   return (
     <ScreenContainer>

--- a/screens/mainScreens/dashboardScreen.tsx
+++ b/screens/mainScreens/dashboardScreen.tsx
@@ -1,382 +1,125 @@
-import { Text, View, StyleSheet, Image, Animated, Easing } from "react-native";
-import ScreenContainer from "../../components/screenContainer/screenContainer";
-import MainHeader from "../../components/mainHeader/mainHeader";
-import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
-import { GLOBAL_STYLES } from "../../lib/globalStyles";
-import HabitsComponent from "../../components/habitsComponent/habitsComponent";
-import AddHabitBtn from "../../components/addHabitBtn/addHabitBtn";
-import { useEffect, useMemo, useRef, useState } from "react";
-import ModalHabit from "../../components/modal/modal";
-import { useHabits } from "../../store/habits";
-import { DIFFICULTY_POINTS } from "../../lib/xp";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Animated,
+  Easing,
+  Image,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 import Svg, { Polygon } from "react-native-svg";
 import { MaterialIcons } from "@expo/vector-icons";
-
-import { useProfile } from "../../store/profile";
-import { Profile } from "../../types/profile";
 import { useSQLiteContext } from "expo-sqlite";
+
+import ScreenContainer from "../../components/screenContainer/screenContainer";
+import AddHabitBtn from "../../components/addHabitBtn/addHabitBtn";
+import HabitsComponent from "../../components/habitsComponent/habitsComponent";
+import ModalHabit from "../../components/modal/modal";
+import { GLOBAL_STYLES } from "../../lib/globalStyles";
+import { useHabits } from "../../store/habits";
+import { useProfile } from "../../store/profile";
+import { formatDateKey, getHeaderLabel } from "../../lib/dateUtils";
+import {
+  countCompletedHabits,
+  selectHabitsForDate,
+} from "../../lib/habitSelectors";
+import { applyDailyProgress } from "../../lib/profileProgress";
+import { persistProfile } from "../../lib/profileStorage";
+import { Profile } from "../../types/profile";
 
 export default function DashboardScreen() {
   const { habits } = useHabits();
   const { profile, setProfile } = useProfile();
-
-  const today = new Date();
-  const dayName = today.toLocaleDateString("en-US", { weekday: "short" });
-  const todayStr = today.toLocaleDateString("en-CA").split("T")[0];
-
-  const headerDayName = today
-    .toLocaleDateString("en-US", { weekday: "long" })
-    .toLowerCase(); // e.g., "thursday"
-  const day = today.getDate(); // e.g., 7
-  const monthName = today
-    .toLocaleDateString("en-US", { month: "long" })
-    .toLowerCase(); // e.g., "august"
-
-  const HeaderDates = `${headerDayName}, ${day} ${monthName}`;
-
-  const todayHabits = useMemo(() => {
-    return habits.filter((habit) => {
-      const { type, days, selectedDate } = habit.repeat;
-
-      if (type === "Daily") return true;
-
-      if (type === "Once" && selectedDate === todayStr) return true;
-
-      if (type === "Custom" && days.includes(dayName)) return true;
-
-      return false;
-    });
-  }, [habits]);
-  const completedCount = todayHabits.filter((item) =>
-    item.completed.includes(todayStr)
-  ).length;
+  const db = useSQLiteContext();
 
   const [modalVisible, setModalVisible] = useState(false);
-  const [editMode, setEditMode] = useState<null | string>(null);
-  const db = useSQLiteContext();
+  const [editMode, setEditMode] = useState<string | null>(null);
   const floatAnim = useRef(new Animated.Value(0)).current;
+
+  const today = new Date();
+  const todayIso = formatDateKey(today);
+  const headerLabel = getHeaderLabel(today);
+  const normalizedToday = useMemo(() => new Date(todayIso), [todayIso]);
+
+  const todayHabits = useMemo(
+    () => selectHabitsForDate(habits, todayIso),
+    [habits, todayIso]
+  );
+
+  const completedCount = useMemo(
+    () => countCompletedHabits(todayHabits, todayIso),
+    [todayHabits, todayIso]
+  );
+
+  const persistProfileMutation = useCallback(
+    async (nextProfile: Profile) => {
+      try {
+        await persistProfile(db, nextProfile);
+      } catch (error) {
+        console.error("Failed to persist profile:", error);
+      }
+    },
+    [db]
+  );
 
   useEffect(() => {
     Animated.loop(
       Animated.sequence([
         Animated.timing(floatAnim, {
-          toValue: -9, // move up 5px
+          toValue: -9,
           duration: 2700,
           easing: Easing.inOut(Easing.sin),
           useNativeDriver: true,
         }),
         Animated.timing(floatAnim, {
-          toValue: 0, // back down
+          toValue: 0,
           duration: 2700,
           easing: Easing.inOut(Easing.sin),
           useNativeDriver: true,
         }),
       ])
     ).start();
-  }, []);
-
-  // useEffect(() => {
-  //   if (todayHabits.length === 0) return;
-
-  //   const yesterday = new Date(today);
-  //   yesterday.setDate(today.getDate() - 1);
-  //   const yesterdayStr = yesterday.toLocaleDateString("en-CA");
-
-  //   setProfile((prev) => {
-  //     const streak = prev.streak || [];
-  //     const lastStreakDate = streak.length ? streak[streak.length - 1] : null;
-
-  //     let updatedProfile = prev;
-
-  //     // Update streak
-  //     if (completedCount === todayHabits.length) {
-  //       if (lastStreakDate !== todayStr && lastStreakDate === yesterdayStr) {
-  //         updatedProfile = { ...prev, streak: [...streak, todayStr] };
-  //       } else if (lastStreakDate !== todayStr) {
-  //         updatedProfile = { ...prev, streak: [todayStr] };
-  //       }
-  //     } else {
-  //       if (lastStreakDate === todayStr) {
-  //         updatedProfile = { ...prev, streak: streak.slice(0, -1) };
-  //       } else if (
-  //         lastStreakDate &&
-  //         lastStreakDate !== yesterdayStr &&
-  //         lastStreakDate !== todayStr
-  //       ) {
-  //         updatedProfile = { ...prev, streak: [] };
-  //       }
-  //     }
-
-  //     // Calculate days missed since last discipline update
-  //     const lastUpdateStr =
-  //       prev.lastDisciplineUpdate || prev.lastUpdateDate || "";
-  //     const lastUpdateDate = lastUpdateStr ? new Date(lastUpdateStr) : null;
-  //     const todayDate = new Date(today);
-
-  //     let daysMissed = 0;
-  //     if (lastUpdateDate) {
-  //       const diffTime = todayDate.getTime() - lastUpdateDate.getTime();
-  //       daysMissed = Math.floor(diffTime / (1000 * 60 * 60 * 24)) - 1; // exclude yesterday
-  //       if (daysMissed < 0) daysMissed = 0;
-  //     }
-
-  //     // Decay for missed days: 5% per missed day
-  //     const decayRate = 0.05;
-  //     let newDiscipline = updatedProfile.stats.discipline || 0;
-  //     if (daysMissed > 0) {
-  //       newDiscipline = newDiscipline * Math.pow(1 - decayRate, daysMissed);
-  //     }
-
-  //     // Add or remove points for today toggle
-  //     const pointsToday = prev.pointsAwardedDates || [];
-  //     const hasAwardedToday = pointsToday.includes(todayStr);
-  //     const pointsToAdd = 0.15;
-
-  //     if (completedCount === todayHabits.length && !hasAwardedToday) {
-  //       newDiscipline = Math.min(100, newDiscipline + pointsToAdd);
-  //       updatedProfile = {
-  //         ...updatedProfile,
-  //         stats: {
-  //           ...updatedProfile.stats,
-  //           discipline: newDiscipline,
-  //         },
-  //         pointsAwardedDates: [...pointsToday, todayStr],
-  //         lastDisciplineUpdate: todayStr,
-  //       };
-  //     } else if (completedCount !== todayHabits.length && hasAwardedToday) {
-  //       newDiscipline = Math.max(0, newDiscipline - pointsToAdd);
-  //       updatedProfile = {
-  //         ...updatedProfile,
-  //         stats: {
-  //           ...updatedProfile.stats,
-  //           discipline: newDiscipline,
-  //         },
-  //         pointsAwardedDates: pointsToday.filter((d) => d !== todayStr),
-  //         lastDisciplineUpdate: todayStr,
-  //       };
-  //     } else {
-  //       // Just update discipline decay without adding/removing points today
-  //       updatedProfile = {
-  //         ...updatedProfile,
-  //         stats: {
-  //           ...updatedProfile.stats,
-  //           discipline: newDiscipline,
-  //         },
-  //         lastDisciplineUpdate: todayStr,
-  //       };
-  //     }
-
-  //     // Calculate overall after discipline update
-  //     const newOverall =
-  //       (newDiscipline +
-  //         (updatedProfile.stats.faith || 0) +
-  //         (updatedProfile.stats.finance || 0) +
-  //         (updatedProfile.stats.fitness || 0) +
-  //         (updatedProfile.stats.focus || 0) +
-  //         (updatedProfile.stats.wisdom || 0)) /
-  //       6;
-
-  //     updatedProfile = {
-  //       ...updatedProfile,
-  //       stats: {
-  //         ...updatedProfile.stats,
-  //         overall: newOverall,
-  //       },
-  //     };
-
-  //     return updatedProfile;
-  //   });
-  // }, [completedCount, todayHabits.length, todayStr]);
+  }, [floatAnim]);
 
   useEffect(() => {
-    if (todayHabits.length === 0) return;
+    if (!todayHabits.length) {
+      return;
+    }
 
-    const updateProfileInDB = async (updatedProfile: Profile) => {
-      try {
-        await db.runAsync(
-          `INSERT OR REPLACE INTO profile 
-        (id, name, level, currentXP, totalXP, age, paid, streak, stats, milestones, pointsAwardedDates, lastDisciplineUpdate) 
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-          [
-            1,
-            updatedProfile.name,
-            updatedProfile.level,
-            updatedProfile.currentXP,
-            updatedProfile.totalXP,
-            updatedProfile.age,
-            updatedProfile.paid ? 1 : 0,
-            JSON.stringify(updatedProfile.streak),
-            JSON.stringify(updatedProfile.stats),
-            JSON.stringify(updatedProfile.milestones),
-            JSON.stringify(updatedProfile.pointsAwardedDates || []),
-            updatedProfile.lastDisciplineUpdate || "",
-          ]
-        );
+    setProfile((previousProfile) => {
+      const updatedProfile = applyDailyProgress(previousProfile, {
+        completedCount,
+        totalHabits: todayHabits.length,
+        today: normalizedToday,
+        todayIso,
+      });
 
-        const rows = await db.getAllAsync("SELECT * FROM profile");
-        console.log("PROFILE TABLE UPDATED:", rows);
-      } catch (err) {
-        console.error("Error updating profile in DB:", err);
-      }
-    };
-
-    setProfile((prev) => {
-      const yesterday = new Date(today);
-      yesterday.setDate(yesterday.getDate() - 1);
-      const yesterdayStr = yesterday.toLocaleDateString("en-CA");
-
-      const streak = prev.streak || [];
-      const lastStreakDate = streak.length ? streak[streak.length - 1] : null;
-
-      let updatedProfile = prev;
-
-      // Update streak
-      if (completedCount === todayHabits.length) {
-        if (lastStreakDate !== todayStr && lastStreakDate === yesterdayStr) {
-          updatedProfile = { ...prev, streak: [...streak, todayStr] };
-        } else if (lastStreakDate !== todayStr) {
-          updatedProfile = { ...prev, streak: [todayStr] };
-        }
-      } else {
-        if (lastStreakDate === todayStr) {
-          updatedProfile = { ...prev, streak: streak.slice(0, -1) };
-        } else if (
-          lastStreakDate &&
-          lastStreakDate !== yesterdayStr &&
-          lastStreakDate !== todayStr
-        ) {
-          updatedProfile = { ...prev, streak: [] };
-        }
+      if (updatedProfile === previousProfile) {
+        return previousProfile;
       }
 
-      // Calculate days missed since last discipline update
-      const lastUpdateStr =
-        prev.lastDisciplineUpdate || prev.lastUpdateDate || "";
-      const lastUpdateDate = lastUpdateStr ? new Date(lastUpdateStr) : null;
-      const todayDate = new Date(today);
-
-      let daysMissed = 0;
-      if (lastUpdateDate) {
-        const diffTime = todayDate.getTime() - lastUpdateDate.getTime();
-        daysMissed = Math.floor(diffTime / (1000 * 60 * 60 * 24)) - 1;
-        if (daysMissed < 0) daysMissed = 0;
-      }
-
-      // Decay for missed days
-      const decayRate = 0.05;
-      let newDiscipline = updatedProfile.stats.discipline || 0;
-      if (daysMissed > 0) {
-        newDiscipline = newDiscipline * Math.pow(1 - decayRate, daysMissed);
-      }
-
-      // Add/remove points for today
-      const pointsToday = prev.pointsAwardedDates || [];
-      const hasAwardedToday = pointsToday.includes(todayStr);
-      const pointsToAdd = 0.15;
-
-      if (completedCount === todayHabits.length && !hasAwardedToday) {
-        newDiscipline = Math.min(100, newDiscipline + pointsToAdd);
-        updatedProfile = {
-          ...updatedProfile,
-          stats: { ...updatedProfile.stats, discipline: newDiscipline },
-          pointsAwardedDates: [...pointsToday, todayStr],
-          lastDisciplineUpdate: todayStr,
-        };
-      } else if (completedCount !== todayHabits.length && hasAwardedToday) {
-        newDiscipline = Math.max(0, newDiscipline - pointsToAdd);
-        updatedProfile = {
-          ...updatedProfile,
-          stats: { ...updatedProfile.stats, discipline: newDiscipline },
-          pointsAwardedDates: pointsToday.filter((d) => d !== todayStr),
-          lastDisciplineUpdate: todayStr,
-        };
-      } else {
-        updatedProfile = {
-          ...updatedProfile,
-          stats: { ...updatedProfile.stats, discipline: newDiscipline },
-          lastDisciplineUpdate: todayStr,
-        };
-      }
-
-      // Update overall
-      const newOverall =
-        (newDiscipline +
-          (updatedProfile.stats.faith || 0) +
-          (updatedProfile.stats.finance || 0) +
-          (updatedProfile.stats.fitness || 0) +
-          (updatedProfile.stats.focus || 0) +
-          (updatedProfile.stats.wisdom || 0)) /
-        6;
-
-      updatedProfile = {
-        ...updatedProfile,
-        stats: { ...updatedProfile.stats, overall: newOverall },
-      };
-
-      // Save to DB
-      updateProfileInDB(updatedProfile);
-
+      void persistProfileMutation(updatedProfile);
       return updatedProfile;
     });
-  }, [completedCount, todayHabits.length, todayStr]);
+  }, [
+    completedCount,
+    normalizedToday,
+    persistProfileMutation,
+    setProfile,
+    todayHabits.length,
+    todayIso,
+  ]);
 
   return (
     <>
       <ScreenContainer>
-        {/* <MainHeader
-          title="Today's Progress"
-          totalCompletedXp={completedTodaysTasks}
-          totalXp={todayHabits.length}
-        /> */}
-        <View
-          style={{
-            flexDirection: "row",
-            alignItems: "center",
-            justifyContent: "space-between",
-          }}
-        >
-          <Text style={styles.headerDate}>{HeaderDates}</Text>
+        <View style={styles.headerRow}>
+          <Text style={styles.headerDate}>{headerLabel}</Text>
           <AddHabitBtn setModalVisible={setModalVisible} />
         </View>
 
-        {/* 
-        <View
-          style={{
-            width: 150,
-            height: 150,
-            borderRadius: "50%",
-            borderWidth: 9,
-            borderColor: GLOBAL_STYLES.accentColor,
-            alignSelf: "center",
-            marginTop: 40,
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          {" "}
-          <Text
-            style={{
-              fontSize: 42,
-              fontWeight: 800,
-              color: GLOBAL_STYLES.accentColor,
-            }}
-          >
-            40%
-          </Text>
-        </View> */}
-
-        {/* <View style={styles.imgContainer}>
-          <Image
-            source={require("../../assets/dashboardImg.png")} // local image
-            style={styles.image}
-            resizeMode="contain"
-          />
-        </View> */}
         <Animated.View
-          style={[
-            styles.imgContainer,
-            { transform: [{ translateY: floatAnim }] },
-          ]}
+          style={[styles.imgContainer, { transform: [{ translateY: floatAnim }] }]}
         >
           <Image
             source={require("../../assets/dashboardImg.png")}
@@ -406,27 +149,26 @@ export default function DashboardScreen() {
           </View>
         </View>
 
-        {/* <AddHabitBtn setModalVisible={setModalVisible} /> */}
-
         <Text style={styles.title}>TODAY'S BATTLES</Text>
 
         <View style={styles.bodyContainer}>
-          {todayHabits.map((data) => (
+          {todayHabits.map((habit) => (
             <HabitsComponent
+              key={habit.id}
               setModalVisible={setModalVisible}
               editMode={editMode}
               setEditMode={setEditMode}
-              key={data.id}
-              name={data.name}
-              completed={data.completed.includes(todayStr) ? true : false}
-              category={data.category}
-              id={data.id}
-              difficulty={data.difficulty}
-              streak={data.streak}
+              name={habit.name}
+              completed={habit.completed.includes(todayIso)}
+              category={habit.category}
+              id={habit.id}
+              difficulty={habit.difficulty}
+              streak={habit.streak}
             />
           ))}
         </View>
       </ScreenContainer>
+
       <ModalHabit
         setModalVisible={setModalVisible}
         visible={modalVisible}
@@ -438,18 +180,17 @@ export default function DashboardScreen() {
 }
 
 const styles = StyleSheet.create({
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
   title: {
     marginTop: 30,
     fontSize: 20,
     color: GLOBAL_STYLES.accentColor,
     fontFamily: "Cinzel-Regular",
     letterSpacing: 2.5,
-  },
-  subTitle: {
-    textAlign: "center",
-    color: GLOBAL_STYLES.secondaryColor,
-    fontSize: GLOBAL_STYLES.subHeader,
-    letterSpacing: 0.8,
   },
   bodyContainer: {
     marginVertical: 24,
@@ -459,21 +200,6 @@ const styles = StyleSheet.create({
     color: GLOBAL_STYLES.primaryColor,
     fontSize: 16,
     fontFamily: "Cinzel-Regular",
-  },
-  streakContainer: {
-    marginTop: 20,
-    flexDirection: "row",
-    gap: 5,
-    backgroundColor: GLOBAL_STYLES.accentColor20,
-    alignSelf: "center",
-    paddingVertical: 9,
-    paddingHorizontal: 30,
-    borderTopColor: GLOBAL_STYLES.accentColor50,
-    borderBottomColor: GLOBAL_STYLES.accentColor50,
-    borderWidth: 1,
-    // border-left: 3px solid transparent,
-
-    // clipPath: polygon(3px 0%, 297px 0%, 100% 100%, 0% 100%);
   },
   streakWrapper: {
     alignSelf: "center",
@@ -506,11 +232,6 @@ const styles = StyleSheet.create({
   image: {
     width: 300,
     height: 300,
-    // backgroundColor: "red",
-    // height: "50%",
-
-    // aspectRatio: 1,
-
     alignSelf: "center",
   },
 });

--- a/screens/mainScreens/mainScreen.tsx
+++ b/screens/mainScreens/mainScreen.tsx
@@ -1,8 +1,6 @@
-import { View, TouchableOpacity } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { NAV_DATA, SCREEN_OPTIONS } from "../../lib/navData";
-import { GLOBAL_STYLES } from "../../lib/globalStyles";
 import { useEffect } from "react";
 import {
   registerForPushNotifications,
@@ -13,11 +11,16 @@ const Tab = createBottomTabNavigator();
 
 export default function MainScreen() {
   useEffect(() => {
-    // Notifications logic
-    (async () => {
-      await registerForPushNotifications();
-      await scheduleDailyNotifications();
-    })();
+    const configureNotifications = async () => {
+      try {
+        await registerForPushNotifications();
+        await scheduleDailyNotifications();
+      } catch (error) {
+        console.error("Failed to configure notifications:", error);
+      }
+    };
+
+    void configureNotifications();
   }, []);
   return (
     <NavigationContainer>

--- a/screens/mainScreens/milestoneScreen.tsx
+++ b/screens/mainScreens/milestoneScreen.tsx
@@ -2,10 +2,13 @@ import { Text, View } from "react-native";
 import ScreenContainer from "../../components/screenContainer/screenContainer";
 import MainHeader from "../../components/mainHeader/mainHeader";
 import MilestonesComponent from "../../components/milestonesComponent/milestonesComponent";
-import { useProfile } from "../../store/profile";
 import { useEffect } from "react";
-import { useHabits } from "../../store/habits";
 import { useSQLiteContext } from "expo-sqlite";
+
+import { useProfile } from "../../store/profile";
+import { useHabits } from "../../store/habits";
+import { updateMilestonesFromHabits } from "../../lib/profileProgress";
+import { persistProfile } from "../../lib/profileStorage";
 
 export default function MilestoneScreen() {
   const { profile, setProfile } = useProfile();
@@ -42,45 +45,17 @@ export default function MilestoneScreen() {
   //   }));
   // }, [habits]);
   useEffect(() => {
-    const uniqueDaysPerPillar: Record<string, Set<string>> = {};
+    const updatedProfile = updateMilestonesFromHabits(profile, habits);
 
-    habits.forEach((habit) => {
-      const pillar = habit.category;
-      if (!uniqueDaysPerPillar[pillar]) uniqueDaysPerPillar[pillar] = new Set();
-      habit.completed.forEach((date) => uniqueDaysPerPillar[pillar].add(date));
-    });
+    if (updatedProfile === profile) {
+      return;
+    }
 
-    const updatedMilestones = profile.milestones.map((m) => {
-      const completed = uniqueDaysPerPillar[m.pillar]?.size >= m.daysRequired;
-      return { ...m, completed };
-    });
-
-    const newProfile = { ...profile, milestones: updatedMilestones };
-
-    // 1. Save to context
-    setProfile(newProfile);
-
-    // 2. Save to SQLite
-    db.runAsync(
-      `INSERT OR REPLACE INTO profile 
-       (id, name, level, currentXP, totalXP, age, paid, streak, stats, milestones)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
-        1,
-        newProfile.name,
-        newProfile.level,
-        newProfile.currentXP,
-        newProfile.totalXP,
-        newProfile.age,
-        newProfile.paid ? 1 : 0,
-        JSON.stringify(newProfile.streak),
-        JSON.stringify(newProfile.stats),
-        JSON.stringify(newProfile.milestones),
-      ]
-    )
-      .then(() => console.log("Milestones updated in SQLite"))
-      .catch((err) => console.error("SQLite update error:", err));
-  }, [habits]);
+    setProfile(updatedProfile);
+    void persistProfile(db, updatedProfile).catch((error) =>
+      console.error("Failed to persist milestone updates:", error)
+    );
+  }, [db, habits, profile, setProfile]);
   return (
     <ScreenContainer>
       <MainHeader

--- a/store/habits.tsx
+++ b/store/habits.tsx
@@ -1,295 +1,19 @@
-// import React, { createContext, useReducer, useContext, ReactNode } from "react";
-// import { Habit } from "../types/habit";
-// import { SQLiteDatabase, useSQLiteContext } from "expo-sqlite";
-
-// type HabitAction =
-//   | { type: "ADD_HABIT"; payload: Habit }
-//   | { type: "UPDATE_HABIT"; payload: Habit }
-//   | { type: "DELETE_HABIT"; payload: string }
-//   | {
-//       type: "TOGGLE_HABIT";
-//       payload: { id: string; date: string; streak: number };
-//     };
-
-// function habitReducer(
-//   state: Habit[],
-//   action: HabitAction,
-//   db: SQLiteDatabase
-// ): Habit[] {
-//   switch (action.type) {
-//     case "ADD_HABIT": {
-//       const newHabit = action.payload;
-
-//       // Save to SQLite
-//       db.runAsync(
-//         `INSERT OR REPLACE INTO habits
-//       (id, name, createDate, completed, streak, difficulty, repeat, category)
-//       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-//         [
-//           newHabit.id,
-//           newHabit.name,
-//           newHabit.createDate || new Date().toISOString(),
-//           JSON.stringify(newHabit.completed || []),
-//           newHabit.streak || 0,
-//           newHabit.difficulty,
-//           JSON.stringify(newHabit.repeat), // <-- stringify object here
-//           newHabit.category,
-//         ]
-//       ).catch((err) => console.error("Failed to save habit to DB:", err));
-
-//       return [...state, newHabit];
-//     }
-
-//     case "UPDATE_HABIT": {
-//       const updatedHabit = action.payload;
-
-//       // Save updated habit to SQLite
-//       db.runAsync(
-//         `UPDATE habits SET
-//       name = ?,
-//       createDate = ?,
-//       completed = ?,
-//       streak = ?,
-//       difficulty = ?,
-//       repeat = ?,
-//       category = ?
-//       WHERE id = ?`,
-//         [
-//           updatedHabit.name,
-//           updatedHabit.createDate || new Date().toISOString(),
-//           JSON.stringify(updatedHabit.completed || []),
-//           updatedHabit.streak || 0,
-//           updatedHabit.difficulty,
-//           JSON.stringify(updatedHabit.repeat), // serialize repeat object
-//           updatedHabit.category,
-//           updatedHabit.id,
-//         ]
-//       ).catch((err) => console.error("Failed to update habit in DB:", err));
-
-//       return state.map((habit) =>
-//         habit.id === updatedHabit.id ? { ...habit, ...updatedHabit } : habit
-//       );
-//     }
-
-//     case "DELETE_HABIT": {
-//       const habitId = action.payload;
-
-//       // Delete habit from SQLite
-//       db.runAsync(`DELETE FROM habits WHERE id = ?`, [habitId]).catch((err) =>
-//         console.error("Failed to delete habit from DB:", err)
-//       );
-
-//       // Remove habit from state
-//       return state.filter((habit) => habit.id !== habitId);
-//     }
-
-//     case "TOGGLE_HABIT": {
-//       const { id, date, streak } = action.payload;
-
-//       return state.map((habit) => {
-//         if (habit.id === id) {
-//           const updatedCompleted = habit.completed?.includes(date)
-//             ? habit.completed.filter((d) => d !== date)
-//             : [...(habit.completed || []), date];
-
-//           // Update habit in SQLite
-//           db.runAsync(
-//             `UPDATE habits SET completed = ?, streak = ? WHERE id = ?`,
-//             [JSON.stringify(updatedCompleted), streak, id]
-//           ).catch((err) => console.error("Failed to update habit in DB:", err));
-
-//           return {
-//             ...habit,
-//             completed: updatedCompleted,
-//             streak,
-//           };
-//         }
-//         return habit;
-//       });
-//     }
-
-//     default:
-//       return state;
-//   }
-// }
-
-// interface HabitContextType {
-//   habits: Habit[];
-//   dispatch: React.Dispatch<HabitAction>;
-// }
-
-// const HabitContext = createContext<HabitContextType | undefined>(undefined);
-
-// export function HabitProvider({ children }: { children: ReactNode }) {
-//   const db = useSQLiteContext();
-
-//   const [habits, dispatch] = useReducer(habitReducer, []);
-//   return (
-//     <HabitContext.Provider value={{ habits, dispatch }}>
-//       {children}
-//     </HabitContext.Provider>
-//   );
-// }
-
-// export function useHabits() {
-//   const context = useContext(HabitContext);
-//   if (!context) {
-//     throw new Error("useHabits must be used within a HabitProvider");
-//   }
-//   return context;
-// }
-
-// Version 2
-
-// import React, { createContext, useReducer, useContext, ReactNode } from "react";
-// import { Habit } from "../types/habit";
-// import { SQLiteDatabase, useSQLiteContext } from "expo-sqlite";
-
-// type HabitAction =
-//   | { type: "ADD_HABIT"; payload: Habit }
-//   | { type: "UPDATE_HABIT"; payload: Habit }
-//   | { type: "DELETE_HABIT"; payload: string }
-//   | {
-//       type: "TOGGLE_HABIT";
-//       payload: { id: string; date: string; streak: number };
-//     };
-
-// function habitReducer(state: Habit[], action: HabitAction): Habit[] {
-//   switch (action.type) {
-//     case "ADD_HABIT":
-//       return [...state, action.payload];
-
-//     case "UPDATE_HABIT":
-//       return state.map((habit) =>
-//         habit.id === action.payload.id ? { ...habit, ...action.payload } : habit
-//       );
-
-//     case "DELETE_HABIT":
-//       return state.filter((habit) => habit.id !== action.payload);
-
-//     case "TOGGLE_HABIT":
-//       return state.map((habit) => {
-//         if (habit.id === action.payload.id) {
-//           const updatedCompleted = habit.completed?.includes(
-//             action.payload.date
-//           )
-//             ? habit.completed.filter((d) => d !== action.payload.date)
-//             : [...(habit.completed || []), action.payload.date];
-
-//           return {
-//             ...habit,
-//             completed: updatedCompleted,
-//             streak: action.payload.streak,
-//           };
-//         }
-//         return habit;
-//       });
-
-//     default:
-//       return state;
-//   }
-// }
-
-// interface HabitContextType {
-//   habits: Habit[];
-//   dispatch: React.Dispatch<HabitAction>;
-// }
-
-// const HabitContext = createContext<HabitContextType | undefined>(undefined);
-
-// export function HabitProvider({ children }: { children: ReactNode }) {
-//   const db = useSQLiteContext();
-//   const [habits, dispatch] = useReducer(habitReducer, []);
-
-//   const wrappedDispatch: React.Dispatch<HabitAction> = (action) => {
-//     // Handle DB operations here
-//     switch (action.type) {
-//       case "ADD_HABIT": {
-//         const h = action.payload;
-//         db.runAsync(
-//           `INSERT OR REPLACE INTO habits (id, name, createDate, completed, streak, difficulty, repeat, category)
-//            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-//           [
-//             h.id,
-//             h.name,
-//             h.createDate || new Date().toISOString(),
-//             JSON.stringify(h.completed || []),
-//             h.streak || 0,
-//             h.difficulty,
-//             JSON.stringify(h.repeat),
-//             h.category,
-//           ]
-//         ).catch((err) => console.error("Failed to save habit to DB:", err));
-//         break;
-//       }
-
-//       case "UPDATE_HABIT": {
-//         const h = action.payload;
-//         db.runAsync(
-//           `UPDATE habits SET name = ?, createDate = ?, completed = ?, streak = ?, difficulty = ?, repeat = ?, category = ? WHERE id = ?`,
-//           [
-//             h.name,
-//             h.createDate || new Date().toISOString(),
-//             JSON.stringify(h.completed || []),
-//             h.streak || 0,
-//             h.difficulty,
-//             JSON.stringify(h.repeat),
-//             h.category,
-//             h.id,
-//           ]
-//         ).catch((err) => console.error("Failed to update habit in DB:", err));
-//         break;
-//       }
-
-//       case "DELETE_HABIT":
-//         db.runAsync(`DELETE FROM habits WHERE id = ?`, [action.payload]).catch(
-//           (err) => console.error("Failed to delete habit from DB:", err)
-//         );
-//         break;
-
-//       case "TOGGLE_HABIT": {
-//         const { id, date, streak } = action.payload;
-//         const habit = habits.find((h) => h.id === id);
-//         if (!habit) break;
-
-//         const updatedCompleted = habit.completed?.includes(date)
-//           ? habit.completed.filter((d) => d !== date)
-//           : [...(habit.completed || []), date];
-
-//         db.runAsync(
-//           `UPDATE habits SET completed = ?, streak = ? WHERE id = ?`,
-//           [JSON.stringify(updatedCompleted), streak, id]
-//         ).catch((err) => console.error("Failed to update habit in DB:", err));
-//         break;
-//       }
-//     }
-
-//     dispatch(action); // update React state
-//   };
-
-//   return (
-//     <HabitContext.Provider value={{ habits, dispatch: wrappedDispatch }}>
-//       {children}
-//     </HabitContext.Provider>
-//   );
-// }
-
-// export function useHabits() {
-//   const context = useContext(HabitContext);
-//   if (!context)
-//     throw new Error("useHabits must be used within a HabitProvider");
-//   return context;
-// }
-
 import React, {
   createContext,
-  useReducer,
   useContext,
-  ReactNode,
   useEffect,
+  useReducer,
+  type ReactNode,
 } from "react";
-import { Habit } from "../types/habit";
-import { useSQLiteContext } from "expo-sqlite";
+import { useSQLiteContext, type SQLiteDatabase } from "expo-sqlite";
+
+import {
+  Habit,
+  HabitCategory,
+  HabitDifficulty,
+  HabitRepeat,
+} from "../types/habit";
+import { formatDateKey } from "../lib/dateUtils";
 
 type HabitAction =
   | { type: "SET_HABITS"; payload: Habit[] }
@@ -305,38 +29,161 @@ function habitReducer(state: Habit[], action: HabitAction): Habit[] {
   switch (action.type) {
     case "SET_HABITS":
       return action.payload;
-
     case "ADD_HABIT":
       return [...state, action.payload];
-
     case "UPDATE_HABIT":
       return state.map((habit) =>
         habit.id === action.payload.id ? { ...habit, ...action.payload } : habit
       );
-
     case "DELETE_HABIT":
       return state.filter((habit) => habit.id !== action.payload);
-
     case "TOGGLE_HABIT":
       return state.map((habit) => {
-        if (habit.id === action.payload.id) {
-          const updatedCompleted = habit.completed?.includes(
-            action.payload.date
-          )
-            ? habit.completed.filter((d) => d !== action.payload.date)
-            : [...(habit.completed || []), action.payload.date];
-
-          return {
-            ...habit,
-            completed: updatedCompleted,
-            streak: action.payload.streak,
-          };
+        if (habit.id !== action.payload.id) {
+          return habit;
         }
-        return habit;
-      });
 
+        const updatedCompleted = habit.completed.includes(action.payload.date)
+          ? habit.completed.filter((date) => date !== action.payload.date)
+          : [...habit.completed, action.payload.date];
+
+        return {
+          ...habit,
+          completed: updatedCompleted,
+          streak: action.payload.streak,
+        };
+      });
     default:
       return state;
+  }
+}
+
+const VALID_REPEAT_TYPES: HabitRepeat["type"][] = [
+  "Daily",
+  "Custom",
+  "Once",
+];
+
+function parseHabitRow(row: any): Habit {
+  let completed: string[] = [];
+  try {
+    completed = row.completed ? JSON.parse(row.completed) : [];
+  } catch (error) {
+    console.error("Failed to parse habit completion data:", error);
+  }
+
+  let repeat: HabitRepeat = { type: "Daily", days: [] };
+  try {
+    const storedRepeat = row.repeat ? JSON.parse(row.repeat) : null;
+    if (
+      storedRepeat &&
+      typeof storedRepeat.type === "string" &&
+      VALID_REPEAT_TYPES.includes(storedRepeat.type) &&
+      Array.isArray(storedRepeat.days)
+    ) {
+      repeat = {
+        type: storedRepeat.type,
+        days: storedRepeat.days,
+        ...(storedRepeat.selectedDate
+          ? { selectedDate: storedRepeat.selectedDate }
+          : {}),
+      } as HabitRepeat;
+    }
+  } catch (error) {
+    console.error("Failed to parse habit repeat data:", error);
+  }
+
+  const difficulty = row.difficulty as HabitDifficulty;
+  const category = row.category as HabitCategory;
+
+  return {
+    id: row.id,
+    name: row.name,
+    createDate: row.createDate ?? formatDateKey(new Date()),
+    completed,
+    streak: row.streak ?? 0,
+    difficulty: difficulty ?? "Medium",
+    repeat,
+    category: category ?? "Faith",
+  };
+}
+
+async function persistHabit(
+  action: HabitAction,
+  db: SQLiteDatabase,
+  habits: Habit[]
+): Promise<void> {
+  try {
+    switch (action.type) {
+      case "ADD_HABIT": {
+        const habit = action.payload;
+        await db.runAsync(
+          `INSERT OR REPLACE INTO habits
+            (id, name, createDate, completed, streak, difficulty, repeat, category)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            habit.id,
+            habit.name,
+            habit.createDate || formatDateKey(new Date()),
+            JSON.stringify(habit.completed ?? []),
+            habit.streak ?? 0,
+            habit.difficulty,
+            JSON.stringify(habit.repeat),
+            habit.category,
+          ]
+        );
+        break;
+      }
+      case "UPDATE_HABIT": {
+        const habit = action.payload;
+        await db.runAsync(
+          `UPDATE habits SET
+              name = ?,
+              createDate = ?,
+              completed = ?,
+              streak = ?,
+              difficulty = ?,
+              repeat = ?,
+              category = ?
+            WHERE id = ?`,
+          [
+            habit.name,
+            habit.createDate || formatDateKey(new Date()),
+            JSON.stringify(habit.completed ?? []),
+            habit.streak ?? 0,
+            habit.difficulty,
+            JSON.stringify(habit.repeat),
+            habit.category,
+            habit.id,
+          ]
+        );
+        break;
+      }
+      case "DELETE_HABIT": {
+        await db.runAsync(`DELETE FROM habits WHERE id = ?`, [action.payload]);
+        break;
+      }
+      case "TOGGLE_HABIT": {
+        const habit = habits.find((item) => item.id === action.payload.id);
+        if (!habit) {
+          break;
+        }
+
+        const updatedCompleted = habit.completed.includes(action.payload.date)
+          ? habit.completed.filter((date) => date !== action.payload.date)
+          : [...habit.completed, action.payload.date];
+
+        await db.runAsync(
+          `UPDATE habits SET completed = ?, streak = ? WHERE id = ?`,
+          [JSON.stringify(updatedCompleted), action.payload.streak, habit.id]
+        );
+        break;
+      }
+      default:
+        break;
+    }
+  } catch (error) {
+    console.error("Failed to persist habit action:", error);
   }
 }
 
@@ -352,83 +199,32 @@ export function HabitProvider({ children }: { children: ReactNode }) {
   const [habits, dispatch] = useReducer(habitReducer, []);
 
   useEffect(() => {
+    let isMounted = true;
+
     const loadHabits = async () => {
       try {
         const rows = await db.getAllAsync<any>("SELECT * FROM habits");
-        const parsed = rows.map((r) => ({
-          ...r,
-          completed: r.completed ? JSON.parse(r.completed) : [],
-          repeat: r.repeat ? JSON.parse(r.repeat) : [],
-        }));
-        dispatch({ type: "SET_HABITS", payload: parsed });
-      } catch (err) {
-        console.error("Failed to load habits:", err);
+        if (!isMounted) return;
+        const parsedHabits = rows.map(parseHabitRow);
+        dispatch({ type: "SET_HABITS", payload: parsedHabits });
+      } catch (error) {
+        console.error("Failed to load habits:", error);
       }
     };
+
     loadHabits();
+
+    return () => {
+      isMounted = false;
+    };
   }, [db]);
 
   const wrappedDispatch: React.Dispatch<HabitAction> = (action) => {
-    switch (action.type) {
-      case "ADD_HABIT": {
-        const h = action.payload;
-        db.runAsync(
-          `INSERT OR REPLACE INTO habits (id, name, createDate, completed, streak, difficulty, repeat, category)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-          [
-            h.id,
-            h.name,
-            h.createDate || new Date().toISOString(),
-            JSON.stringify(h.completed || []),
-            h.streak || 0,
-            h.difficulty,
-            JSON.stringify(h.repeat),
-            h.category,
-          ]
-        );
-        break;
-      }
-
-      case "UPDATE_HABIT": {
-        const h = action.payload;
-        db.runAsync(
-          `UPDATE habits SET name = ?, createDate = ?, completed = ?, streak = ?, difficulty = ?, repeat = ?, category = ? WHERE id = ?`,
-          [
-            h.name,
-            h.createDate,
-            JSON.stringify(h.completed || []),
-            h.streak,
-            h.difficulty,
-            JSON.stringify(h.repeat),
-            h.category,
-            h.id,
-          ]
-        );
-        break;
-      }
-
-      case "DELETE_HABIT":
-        db.runAsync(`DELETE FROM habits WHERE id = ?`, [action.payload]);
-        break;
-
-      case "TOGGLE_HABIT": {
-        const { id, date, streak } = action.payload;
-        const habit = habits.find((h) => h.id === id);
-        if (!habit) break;
-
-        const updatedCompleted = habit.completed?.includes(date)
-          ? habit.completed.filter((d) => d !== date)
-          : [...(habit.completed || []), date];
-
-        db.runAsync(
-          `UPDATE habits SET completed = ?, streak = ? WHERE id = ?`,
-          [JSON.stringify(updatedCompleted), streak, id]
-        );
-        break;
-      }
+    if (action.type !== "SET_HABITS") {
+      void persistHabit(action, db, habits);
     }
 
-    dispatch(action); // always update context
+    dispatch(action);
   };
 
   return (
@@ -440,7 +236,8 @@ export function HabitProvider({ children }: { children: ReactNode }) {
 
 export function useHabits() {
   const context = useContext(HabitContext);
-  if (!context)
+  if (!context) {
     throw new Error("useHabits must be used within a HabitProvider");
+  }
   return context;
 }

--- a/store/profile.tsx
+++ b/store/profile.tsx
@@ -1,67 +1,20 @@
-// import React, {
-//   createContext,
-//   useReducer,
-//   useContext,
-//   ReactNode,
-//   useState,
-// } from "react";
-// import { Habit } from "../types/habit";
-// import { Profile } from "../types/profile";
-// import { MILESTONES_DATA } from "../lib/milestonesData";
-
-// const ProfileContext = createContext<ProfileContextType | undefined>(undefined);
-// const initialProfile = {
-//   name: "",
-//   milestones: MILESTONES_DATA,
-//   level: 1,
-//   currentXP: 0,
-//   totalXP: 0,
-//   age: "18-24",
-//   paid: false,
-//   streak: [],
-//   stats: {
-//     overall: 0,
-//     discipline: 0,
-//     focus: 0,
-//     wisdom: 0,
-//     fitness: 0,
-//     faith: 0,
-//     finance: 0,
-//   },
-// };
-
-// type ProfileContextType = {
-//   profile: Profile;
-//   setProfile: React.Dispatch<React.SetStateAction<Profile>>;
-// };
-
-// export function ProfileProvider({ children }: { children: ReactNode }) {
-//   const [profile, setProfile] = useState<Profile>(initialProfile);
-//   return (
-//     <ProfileContext.Provider value={{ profile, setProfile }}>
-//       {children}
-//     </ProfileContext.Provider>
-//   );
-// }
-
-// export function useProfile() {
-//   const context = useContext(ProfileContext);
-//   if (!context) {
-//     throw new Error("useProfile must be used within a ProfileProvider");
-//   }
-//   return context;
-// }
-
 import React, {
   createContext,
+  type ReactNode,
   useContext,
-  useState,
   useEffect,
-  ReactNode,
+  useState,
 } from "react";
 import { useSQLiteContext } from "expo-sqlite";
+
 import { Profile } from "../types/profile";
 import { MILESTONES_DATA } from "../lib/milestonesData";
+import { persistProfile } from "../lib/profileStorage";
+
+type ProfileContextType = {
+  profile: Profile;
+  setProfile: React.Dispatch<React.SetStateAction<Profile>>;
+};
 
 const ProfileContext = createContext<ProfileContextType | undefined>(undefined);
 
@@ -83,11 +36,7 @@ const initialProfile: Profile = {
     faith: 0,
     finance: 0,
   },
-};
-
-type ProfileContextType = {
-  profile: Profile;
-  setProfile: React.Dispatch<React.SetStateAction<Profile>>;
+  pointsAwardedDates: [],
 };
 
 export function ProfileProvider({ children }: { children: ReactNode }) {
@@ -95,42 +44,44 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
   const [profile, setProfile] = useState<Profile>(initialProfile);
 
   useEffect(() => {
+    let isMounted = true;
+
     const loadProfile = async () => {
       try {
         const row = await db.getFirstAsync<any>("SELECT * FROM profile");
+        if (!isMounted) return;
+
         if (row) {
           setProfile({
-            ...row,
+            name: row.name ?? initialProfile.name,
+            level: row.level ?? initialProfile.level,
+            currentXP: row.currentXP ?? initialProfile.currentXP,
+            totalXP: row.totalXP ?? initialProfile.totalXP,
+            age: row.age ?? initialProfile.age,
             paid: !!row.paid,
-            milestones: row.milestones
-              ? JSON.parse(row.milestones)
-              : MILESTONES_DATA,
-            streak: row.streak ? JSON.parse(row.streak) : [],
-            stats: row.stats ? JSON.parse(row.stats) : initialProfile.stats,
+            streak: safelyParseJson(row.streak, []),
+            stats: safelyParseJson(row.stats, initialProfile.stats),
+            milestones: safelyParseJson(row.milestones, MILESTONES_DATA),
+            pointsAwardedDates: safelyParseJson(row.pointsAwardedDates, []),
+            lastDisciplineUpdate: row.lastDisciplineUpdate || undefined,
+            lastUpdateDate: row.lastUpdateDate || undefined,
           });
         } else {
-          // insert default if none exists
-          await db.runAsync(
-            `INSERT INTO profile (name, level, currentXP, totalXP, age, paid, milestones, streak, stats) 
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-            [
-              initialProfile.name,
-              initialProfile.level,
-              initialProfile.currentXP,
-              initialProfile.totalXP,
-              initialProfile.age,
-              initialProfile.paid ? 1 : 0,
-              JSON.stringify(initialProfile.milestones),
-              JSON.stringify(initialProfile.streak),
-              JSON.stringify(initialProfile.stats),
-            ]
-          );
+          await persistProfile(db, initialProfile);
+          if (isMounted) {
+            setProfile(initialProfile);
+          }
         }
-      } catch (err) {
-        console.error("Failed to load profile:", err);
+      } catch (error) {
+        console.error("Failed to load profile:", error);
       }
     };
+
     loadProfile();
+
+    return () => {
+      isMounted = false;
+    };
   }, [db]);
 
   return (
@@ -140,9 +91,23 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
   );
 }
 
+function safelyParseJson<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    console.error("Failed to parse profile value:", error);
+    return fallback;
+  }
+}
+
 export function useProfile() {
   const context = useContext(ProfileContext);
-  if (!context)
+  if (!context) {
     throw new Error("useProfile must be used within a ProfileProvider");
+  }
   return context;
 }

--- a/types/habit.ts
+++ b/types/habit.ts
@@ -1,10 +1,24 @@
+export type HabitDifficulty = "Easy" | "Medium" | "Hard";
+
+export type HabitCategory =
+  | "Faith"
+  | "Focus"
+  | "Fitness"
+  | "Wisdom"
+  | "Finance";
+
+export type HabitRepeat =
+  | { type: "Daily"; days: string[] }
+  | { type: "Custom"; days: string[] }
+  | { type: "Once"; days: string[]; selectedDate?: string };
+
 export type Habit = {
   id: string;
   name: string;
   createDate: string;
   completed: string[];
   streak: number;
-  difficulty: "Easy" | "Medium" | "Hard";
-  repeat: { type: string; days: string[]; selectedDate?: string };
-  category: "Faith" | "Focus" | "Fitness" | "Wisdom";
+  difficulty: HabitDifficulty;
+  repeat: HabitRepeat;
+  category: HabitCategory;
 };


### PR DESCRIPTION
## Summary
- add reusable date, habit selection, and profile persistence utilities to centralize daily progress logic
- refactor dashboard, calendar, and milestone screens to use the new helpers while persisting profile updates safely
- streamline habit components, modal form handling, and store providers for better typing and SQLite consistency

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d3f27679488327af4f7332b01580c9